### PR TITLE
Add documentation for analyzer releases 2.0.0

### DIFF
--- a/src/IeuanWalker.AppSettings.Generator/AnalyzerReleases.Shipped.md
+++ b/src/IeuanWalker.AppSettings.Generator/AnalyzerReleases.Shipped.md
@@ -1,0 +1,12 @@
+﻿; Shipped analyzer releases
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+## Release 2.0.0
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+APPSET001 | AppSettings | Error | AppSettingsSourceGenerator
+APPSET002 | AppSettings | Warning | AppSettingsSourceGenerator
+

--- a/src/IeuanWalker.AppSettings.Generator/AnalyzerReleases.Unshipped.md
+++ b/src/IeuanWalker.AppSettings.Generator/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,2 @@
+﻿; Unshipped analyzer release
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md


### PR DESCRIPTION
Updated AnalyzerReleases.Shipped.md and AnalyzerReleases.Unshipped.md to include details for Release 2.0.0. Added new rules related to AppSettingsSourceGenerator, specifying their IDs, categories, severities, and notes.